### PR TITLE
Fix mobile homepage overlap and chatbot behavior

### DIFF
--- a/components/chatbot.tsx
+++ b/components/chatbot.tsx
@@ -20,19 +20,12 @@ export const Chatbot = () => {
     const [isMobile, setIsMobile] = useState<boolean | null>(null);
 
     useEffect(() => {
-        if (typeof window === "undefined") return;
-
         const mediaQuery = window.matchMedia("(max-width: 640px)");
         const updateIsMobile = () => setIsMobile(mediaQuery.matches);
         updateIsMobile();
 
-        if (mediaQuery.addEventListener) {
-            mediaQuery.addEventListener("change", updateIsMobile);
-            return () => mediaQuery.removeEventListener("change", updateIsMobile);
-        }
-
-        mediaQuery.addListener(updateIsMobile);
-        return () => mediaQuery.removeListener(updateIsMobile);
+        mediaQuery.addEventListener("change", updateIsMobile);
+        return () => mediaQuery.removeEventListener("change", updateIsMobile);
     }, []);
 
     const mobileMode = isMobile ?? false;
@@ -228,7 +221,7 @@ export const Chatbot = () => {
                         div.fixed {
                             width: min(92vw, 360px) !important;
                             right: 12px !important;
-                            bottom: calc(env(safe-area-inset-bottom, 0px) + 82px) !important;
+                            bottom: calc(env(safe-area-inset-bottom, 0px) + ${chatWindowOffset}px) !important;
                         }
                         .chatbot-container {
                             max-height: min(68dvh, 500px) !important;

--- a/components/chatbot.tsx
+++ b/components/chatbot.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import dynamic from "next/dynamic";
 
 const BubbleChat = dynamic(
@@ -17,6 +17,31 @@ export const Chatbot = () => {
     const MUTED_COLOR = "#A3A3A3";
     const BOT_BG = "#171717";
     const USER_BG = "#262626";
+    const [isMobile, setIsMobile] = useState<boolean | null>(null);
+
+    useEffect(() => {
+        if (typeof window === "undefined") return;
+
+        const mediaQuery = window.matchMedia("(max-width: 640px)");
+        const updateIsMobile = () => setIsMobile(mediaQuery.matches);
+        updateIsMobile();
+
+        if (mediaQuery.addEventListener) {
+            mediaQuery.addEventListener("change", updateIsMobile);
+            return () => mediaQuery.removeEventListener("change", updateIsMobile);
+        }
+
+        mediaQuery.addListener(updateIsMobile);
+        return () => mediaQuery.removeListener(updateIsMobile);
+    }, []);
+
+    const mobileMode = isMobile ?? false;
+    const bubbleSize = mobileMode ? 60 : 80;
+    const bubbleRight = mobileMode ? 12 : 20;
+    const bubbleBottom = mobileMode ? 12 : 20;
+    const chatWindowOffset = bubbleBottom + bubbleSize + 10;
+    const chatWindowHeight = mobileMode ? 500 : 550;
+    const chatWindowWidth = mobileMode ? 360 : 400;
 
     useEffect(() => {
         const findAndClickChatButton = () => {
@@ -127,8 +152,11 @@ export const Chatbot = () => {
         };
     }, []);
 
+    if (isMobile === null) return null;
+
     return (
         <BubbleChat
+            key={mobileMode ? "mobile" : "desktop"}
             chatflowid="a6759d77-8fe9-459f-abb2-7a9aacd22ccf"
             apiHost="https://flowise.avishekmajumder.com"
             chatflowConfig={{
@@ -142,10 +170,10 @@ export const Chatbot = () => {
             theme={{
                 button: {
                     backgroundColor: "#000000",
-                    right: 20,
-                    bottom: 20,
-                    size: 80, // Much bigger as requested
-                    dragAndDrop: true,
+                    right: bubbleRight,
+                    bottom: bubbleBottom,
+                    size: bubbleSize,
+                    dragAndDrop: !mobileMode,
                     iconColor: "white",
                     customIconSrc: irisIconSrc,
                     autoWindowOpen: {
@@ -155,8 +183,8 @@ export const Chatbot = () => {
                     },
                 },
                 tooltip: {
-                    showTooltip: true,
-                    tooltipMessage: "Ask Iris (Cmd+K)",
+                    showTooltip: !mobileMode,
+                    tooltipMessage: "Ask Iris",
                     tooltipBackgroundColor: "#000000",
                     tooltipTextColor: "white",
                     tooltipFontSize: 12,
@@ -178,15 +206,15 @@ export const Chatbot = () => {
                     }
                     /* Position the outer fixed wrapper — applies to both .chatbot-container AND the close button */
                     div.fixed {
-                        bottom: 110px !important; /* 20px button-bottom + 80px button-size + 10px gap */
-                        right: 20px !important;
+                        bottom: calc(env(safe-area-inset-bottom, 0px) + ${chatWindowOffset}px) !important;
+                        right: ${bubbleRight}px !important;
                     }
                     /* Force Dark Mode Overrides */
                     .chatbot-container {
                         border: 1px solid #D97706 !important; /* Thin orange outline for window */
                         box-shadow: 0 20px 50px rgba(0,0,0,0.5) !important;
                         font-family: 'IBM Plex Mono', monospace !important;
-                        max-height: calc(100vh - 140px) !important; /* Prevent clipping */
+                        max-height: min(78dvh, calc(100vh - 140px)) !important;
                     }
                     /* Fix Close Button — override Flowise's right-[-8px] that pushes it outside */
                     button[class*="absolute"][class*="right-"] {
@@ -198,12 +226,12 @@ export const Chatbot = () => {
                     /* Mobile Responsiveness */
                     @media (max-width: 640px) {
                         div.fixed {
-                            width: 90% !important;
-                            right: 5% !important;
-                            bottom: 110px !important;
+                            width: min(92vw, 360px) !important;
+                            right: 12px !important;
+                            bottom: calc(env(safe-area-inset-bottom, 0px) + 82px) !important;
                         }
                         .chatbot-container {
-                            max-height: 70vh !important;
+                            max-height: min(68dvh, 500px) !important;
                         }
                     }
 
@@ -281,8 +309,8 @@ export const Chatbot = () => {
                         "Connection Interrupted. Retrying...",
                     backgroundColor: BG_COLOR,
                     backgroundImage: "",
-                    height: 550, // Reduced height to fit smaller screens and sit lower
-                    width: 400,
+                    height: chatWindowHeight,
+                    width: chatWindowWidth,
                     fontSize: 14,
                     starterPrompts: [
                         "Analyze my workflow",

--- a/components/what-we-do-section.tsx
+++ b/components/what-we-do-section.tsx
@@ -50,7 +50,7 @@ export default function WhatWeDoSection() {
 
             <div className="mx-auto max-w-7xl px-6 relative z-10">
                 <div className="grid gap-16 lg:grid-cols-[0.9fr_1.1fr] lg:items-start">
-                    <div className="text-white sticky top-32">
+                    <div className="text-white lg:sticky lg:top-32">
                         <div className="flex items-center gap-3 mb-6">
                             <div className="h-px w-8 bg-primary/60"></div>
                             <p className="text-xs font-mono uppercase tracking-[0.22em] text-primary">


### PR DESCRIPTION
## Summary
- make the homepage Phase 1 left column sticky only on large screens to prevent mobile overlap between "Explicitly Out of Scope" and "One Real Bottleneck"
- add mobile-aware chatbot behavior (bubble size/position, safe-area offsets, window sizing)
- hide desktop-only tooltip on mobile and remount chatbot config by breakpoint for consistent Flowise init

## Validation
- npm run lint -- components/chatbot.tsx
- headed Playwright checks at mobile viewport (390x844)
- verified overlap metrics remain clear: overlapArea=0, isOverlapping=false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile-aware responsive chat UI: device detection drives button and window sizing/positioning, mobile-specific tooltips, and drag behavior adjustments; initial render waits until device type is determined.

* **Changes**
  * Sticky section now applies only on larger screens (no longer universally sticky), improving responsive layout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->